### PR TITLE
fix parallelism of `dmap`

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -310,7 +310,7 @@ Call a function `fn` on `workers`, with a single parameter arriving from the
 corresponding position in `arr`.
 """
 function dmap(arr::Vector, fn, workers)
-    fetch.([get_from(w, :($fn($(arr[i])))) for (i, w) in enumerate(workers)])
+    map(fetch, [get_from(w, :($fn($(arr[i])))) for (i, w) in enumerate(workers)])
 end
 
 """

--- a/test/base.jl
+++ b/test/base.jl
@@ -86,14 +86,14 @@
     end
 
     @testset "`pmap` on distributed data" begin
-        fetch.(save_at.(W, :test, 1234321))
+        map(fetch, save_at.(W, :test, 1234321))
         di = Dinfo(:test, W) # also test the example in docs
         @test dpmap(
             x -> :($(di.val) + $x),
             WorkerPool(di.workers),
             [4321234, 1234, 4321],
         ) == [5555555, 1235555, 1238642]
-        fetch.(remove_from.(W, :test))
+        map(fetch, remove_from.(W, :test))
     end
 
     @testset "Internal utilities" begin


### PR DESCRIPTION
- broadcasts are sometimes (often) fusing with other stuff, which is not what we really want here
- apply the same to docs and tests


(note: this is well-aged contents, I found this laying here from like March or so)